### PR TITLE
Update null Room data

### DIFF
--- a/app/src/main/java/org/selfconference/android/session/Room.java
+++ b/app/src/main/java/org/selfconference/android/session/Room.java
@@ -1,21 +1,27 @@
 package org.selfconference.android.session;
 
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
 import com.google.auto.value.AutoValue;
 
 @AutoValue public abstract class Room implements Parcelable {
 
-  public static Room emptyRoom() {
-    return create(-1, "");
+  /** Returns a Null Object to represent missing room data. */
+  @NonNull public static Room nullRoom() {
+    return create(-1, "TBD");
   }
 
-  public static Room create(int id, String name) {
+  /** A factory method that returns a {@code Room} instance. */
+  @NonNull public static Room create(int id, String name) {
     return new AutoValue_Room(id, name);
   }
 
+  /** A no-args constructor used by {@link com.google.gson.Gson}. */
   Room() {}
 
+  /** Returns the room's database ID. */
   public abstract int id();
 
+  /** Returns the room's human-readable name. */
   public abstract String name();
 }

--- a/app/src/main/java/org/selfconference/android/session/RoomJsonDeserializer.java
+++ b/app/src/main/java/org/selfconference/android/session/RoomJsonDeserializer.java
@@ -20,7 +20,7 @@ public final class RoomJsonDeserializer implements JsonDeserializer<Room> {
       return Room.create(id, name);
     }
 
-    return Room.emptyRoom();
+    return Room.nullRoom();
   }
 
   private static boolean hasRoomProperties(JsonObject jsonObject) {

--- a/app/src/main/java/org/selfconference/android/session/Session.java
+++ b/app/src/main/java/org/selfconference/android/session/Session.java
@@ -1,6 +1,7 @@
 package org.selfconference.android.session;
 
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -21,7 +22,7 @@ import org.selfconference.android.speakers.Speaker;
 
   public abstract String title();
 
-  public abstract Room room();
+  @NonNull public abstract Room room();
 
   public abstract String description();
 

--- a/app/src/main/java/org/selfconference/android/session/SessionAdapter.java
+++ b/app/src/main/java/org/selfconference/android/session/SessionAdapter.java
@@ -55,9 +55,7 @@ public class SessionAdapter extends FilterableAdapter<Session, SessionAdapter.Se
     holder.favoriteSessionIndicator.setVisibility(preferences.isFavorite(session) ? VISIBLE : GONE);
 
     holder.sessionTitle.setText(session.title());
-    if (session.room() != null) {
-      holder.sessionSubtitle.setText(session.room().name());
-    }
+    holder.sessionSubtitle.setText(session.room().name());
     try {
       final Session previousSession = getFilteredData().get(position - 1);
       if (session.beginning() != null) {

--- a/app/src/main/java/org/selfconference/android/session/SessionDetailsActivity.java
+++ b/app/src/main/java/org/selfconference/android/session/SessionDetailsActivity.java
@@ -14,7 +14,6 @@ import android.widget.TextView;
 import butterknife.Bind;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import com.google.common.collect.ImmutableList;
 import com.squareup.otto.Bus;
 import com.squareup.otto.Subscribe;
 import java.util.List;
@@ -122,21 +121,18 @@ public final class SessionDetailsActivity extends BaseActivity {
   private void setupFeedbackButton() {
     final boolean hasSubmittedFeedback = preferences.hasSubmittedFeedback(session);
     submitFeedback.setText(
-            hasSubmittedFeedback ? R.string.feedback_submitted : R.string.submit_feedback);
+        hasSubmittedFeedback ? R.string.feedback_submitted : R.string.submit_feedback);
     submitFeedback.setEnabled(!hasSubmittedFeedback);
   }
 
   private void setUpSessionDetailList() {
     SessionDetails.Builder builder = SessionDetails.builder();
-    if (session.room() != null) {
-      builder.add(R.drawable.ic_maps_place, session.room().name());
-    }
+    builder.add(R.drawable.ic_maps_place, session.room().name());
     if (session.beginning() != null) {
       builder.add(R.drawable.ic_action_schedule, toDateString(session.beginning()));
     }
-    List<SessionDetail> sessionDetails = builder
-        .add(R.drawable.ic_action_description, fromHtml(session.description()))
-        .toList();
+    List<SessionDetail> sessionDetails =
+        builder.add(R.drawable.ic_action_description, fromHtml(session.description())).toList();
 
     SessionDetailAdapter sessionDetailAdapter = new SessionDetailAdapter(sessionDetails);
     sessionDetailRecyclerView.setAdapter(sessionDetailAdapter);

--- a/app/src/main/java/org/selfconference/android/session/SessionJsonDeserializer.java
+++ b/app/src/main/java/org/selfconference/android/session/SessionJsonDeserializer.java
@@ -54,7 +54,7 @@ public final class SessionJsonDeserializer implements JsonDeserializer<Session> 
     Room room() {
       JsonElement roomJsonObject = jsonObject.get("room");
       Room room = context.deserialize(roomJsonObject, Room.class);
-      return Optional.fromNullable(room).or(Room.emptyRoom());
+      return Optional.fromNullable(room).or(Room.nullRoom());
     }
 
     @Nullable DateTime beginning() {

--- a/app/src/test/java/org/selfconference/android/session/RoomJsonDeserializerTest.java
+++ b/app/src/test/java/org/selfconference/android/session/RoomJsonDeserializerTest.java
@@ -18,7 +18,7 @@ public final class RoomJsonDeserializerTest {
   @Test public void deserializesNullRoom() {
     Room room = gson.fromJson("{}", Room.class);
 
-    assertThat(room).isEqualTo(Room.emptyRoom());
+    assertThat(room).isEqualTo(Room.nullRoom());
   }
 
   @Test public void deserializesValidRoom() {

--- a/app/src/test/java/org/selfconference/android/session/SessionJsonDeserializerTest.java
+++ b/app/src/test/java/org/selfconference/android/session/SessionJsonDeserializerTest.java
@@ -37,7 +37,7 @@ public final class SessionJsonDeserializerTest {
   @Test public void deserializesMissingRoomAsEmptyRoom() {
     Session session = gson.fromJson(sessionWithoutRoomJson(), Session.class);
 
-    assertThat(session).hasRoom(Room.emptyRoom());
+    assertThat(session).hasRoom(Room.nullRoom());
   }
 
   private static String completeSessionJson() {

--- a/app/src/test/java/org/selfconference/android/session/SessionPreferencesTest.java
+++ b/app/src/test/java/org/selfconference/android/session/SessionPreferencesTest.java
@@ -24,7 +24,7 @@ public final class SessionPreferencesTest {
     Session session = Session.builder() //
         .id(13)
         .title("Title")
-        .room(Room.emptyRoom())
+        .room(Room.nullRoom())
         .description("Description")
         .keynote(false)
         .speakers(ImmutableList.of())

--- a/app/src/test/java/org/selfconference/android/session/SessionTest.java
+++ b/app/src/test/java/org/selfconference/android/session/SessionTest.java
@@ -23,7 +23,7 @@ public final class SessionTest {
         .id(4)
         .beginning(now())
         .description("description")
-        .room(Room.emptyRoom())
+        .room(Room.nullRoom())
         .speakers(ImmutableList.of(Speaker.builder() //
             .id(3)
             .name("Name")

--- a/app/src/test/java/org/selfconference/android/speakers/SpeakerTest.java
+++ b/app/src/test/java/org/selfconference/android/speakers/SpeakerTest.java
@@ -28,7 +28,7 @@ public final class SpeakerTest {
         .addSessions(asList(Session.builder() //
             .id(10)
             .title("Title")
-            .room(Room.emptyRoom())
+            .room(Room.nullRoom())
             .description("Description")
             .keynote(false)
             .speakers(ImmutableList.of())


### PR DESCRIPTION
This commit renames `Room#emptyRoom` to `Room#nullRoom` with
documentation about this Null Object’s purpose. It also uses “TBD” as
the null Room’s default name.

This leaves a `Session` without a `Room` rendering like:

![shamummb29qmacklinu03302016115623](https://cloud.githubusercontent.com/assets/2344137/14148755/d2fe4308-f66e-11e5-9cf1-ef045eb48241.png)